### PR TITLE
fix to get all content of a bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ from pythoncosmicjs import Api
 # Configure
 api = Api(bucket='bucket-slug', read_key='read_key', write_key='write_key')
 # Get all contents of bucket including objects and media
-print(api.bucket())
+print(api.get_bucket())
 # Get all objects
 print(api.objects(limit=10, skip=5)) # limit, skip the default is None
 # Get objects by type

--- a/pythoncosmicjs/api.py
+++ b/pythoncosmicjs/api.py
@@ -7,8 +7,8 @@ class Api(object):
         self.read_key = '?read_key=%s' % read_key if read_key else ''
         self.write_key = '?write_key=%s' % write_key if write_key else ''
 
-    def bucket(self):
-        url = '%s/%s/' % (self.base_url, self.bucket)
+    def get_bucket(self):
+        url = '%s/%s%s' % (self.base_url, self.bucket, self.read_key)
         return self.deserialization(url)
 
     def objects(self, limit=None, skip=None):


### PR DESCRIPTION
- Changed name of function to get_bucket because there was a conflict with the class variable called bucket.
- URL for get_bucket was missing read-key